### PR TITLE
Convert to POSIX + bug fixes

### DIFF
--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -175,10 +175,10 @@ cmpPorts() {
 progressBar() {
         [ -z "${2##*[!0-9]*}" ] && return 1
         [ "$(stty size | cut -d ' ' -f 2)" -le 120 ] && width=50 || width=100
-        fill="$(printf "%-$((width == 100 ? $2 : ($2 / 2)))s" "#")"
+        fill="$(printf "%-$((width == 100 ? $2 : ($2 / 2)))s" "#" | tr ' ' '#')"
         empty="$(printf "%-$((width - (width == 100 ? $2 : ($2 / 2))))s" " ")"
         printf "In progress: $1 Scan ($3 elapsed - $4 remaining)   \n"
-        printf "[${fill// /\#}>${empty// / }] $2% done   \n"
+        printf "[${fill}>${empty}] $2% done   \n"
         printf "\e[2A"
 }
 

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -355,7 +355,7 @@ vulnsScan() {
 recon() {
 
         reconRecommend "${HOST}" | tee "nmap/Recon_${HOST}.nmap"
-        allRecon="$(grep "${HOST}" "nmap/Recon_${HOST}.nmap" | cut -d " " -f 1 | sort -u)"
+        allRecon="$(grep "${HOST}" "nmap/Recon_${HOST}.nmap" | cut -d " " -f 1 | sort | uniq)"
 
         for tool in ${allRecon}; do
                 if ! type "${tool}" 2>/dev/null | grep -q bin; then
@@ -421,7 +421,7 @@ reconRecommend() {
 
         if [ -f "nmap/Full_Extra_${HOST}.nmap" ]; then
                 ports="${allPorts}"
-                file="$(cat "nmap/Basic_${HOST}.nmap" "nmap/Full_Extra_${HOST}.nmap" | grep "open" | sort -u)"
+                file="$(cat "nmap/Basic_${HOST}.nmap" "nmap/Full_Extra_${HOST}.nmap" | grep "open" | sort | uniq)"
         else
                 ports="${basicPorts}"
                 file="$(grep "open" "nmap/Basic_${HOST}.nmap")"
@@ -568,7 +568,7 @@ runRecon() {
         fi
 
         for line in ${reconCommands}; do
-                currentScan="$(echo "${line}" | cut -d " " -f 1 | sort -u | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)"
+                currentScan="$(echo "${line}" | cut -d " " -f 1 | sort | uniq | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)"
                 fileName="$(echo "${line}" | awk -F "recon/" '{print $2}' | head -c-1)"
                 if [ -n "${fileName}" ] && [ ! -f recon/"${fileName}" ]; then
                         echo -e "${NC}"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -595,12 +595,12 @@ footer() {
         echo -e "${NC}"
         echo -e ""
 
-        if (($SECONDS > 3600)); then
+        if [ ${SECONDS} -gt 3600 ]; then
                 let "hours=SECONDS/3600"
                 let "minutes=(SECONDS%3600)/60"
                 let "seconds=(SECONDS%3600)%60"
-        elif (($SECONDS > 60)); then
                 echo -e "${YELLOW}Completed in ${hours} hour(s), ${minutes} minute(s) and ${seconds} second(s)"
+        elif [ ${SECONDS} -gt 60 ]; then
                 let "minutes=(SECONDS%3600)/60"
                 let "seconds=(SECONDS%3600)%60"
                 echo -e "${YELLOW}Completed in ${minutes} minute(s) and ${seconds} second(s)"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -411,7 +411,8 @@ reconRecommend() {
         printf "${NC}\n"
 
         oldIFS="${IFS}"
-        IFS=$'\n'
+        IFS="
+"
 
         if [ -f "nmap/Full_Extra_${HOST}.nmap" ]; then
                 ports="${allPorts}"
@@ -552,7 +553,8 @@ runRecon() {
         printf "${NC}\n"
 
         oldIFS="${IFS}"
-        IFS=$'\n'
+        IFS="
+"
 
         mkdir -p recon/
 

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -455,7 +455,8 @@ reconRecommend() {
                 cms="$(grep http-generator "nmap/Basic_${HOST}.nmap" | cut -d " " -f 2)"
                 if [ -n "${cms}" ]; then
                         for line in ${cms}; do
-                                port="$(grep "${line}" -B1 "nmap/Basic_${HOST}.nmap" | grep "open" | cut -d "/" -f 1)"
+                                port="$(sed -n 'H;x;s/\/.*'"${line}"'.*//p' "nmap/Basic_${HOST}.nmap")"
+
                                 # case returns 0 by default (no match), so ! case returns 1
                                 if ! case "${cms}" in Joomla|WordPress|Drupal) false;; esac; then
                                         printf "${NC}\n"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -380,7 +380,7 @@ recon() {
         if [ -n "${availableRecon}" ]; then
                 while [ "${reconCommand}" != "!" ]; do
                         echo -e "${YELLOW}"
-                        echo -e "Which commands would you like to run?${NC}\nAll (Default), ${availableRecon}, Skip <!>\n"
+                        echo -e "Which commands would you like to run?${NC}\nAll (Default), ${availableRecon}Skip <!>\n"
                         while [ ${count} -lt ${secs} ]; do
                                 tlimit=$((secs - count))
                                 echo -e "\rRunning Default in (${tlimit}) s: \c"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -64,7 +64,7 @@ if [ -z "${OUTPUTDIR}" ]; then
 fi
 
 usage() {
-        echo -e ""
+        echo
         echo -e "${RED}Usage: $0 -H/--host <TARGET-IP> -t/--type <TYPE> [-d/--dns <DNS SERVER> -o/--output <OUTPUT DIRECTORY>]"
         echo -e "${YELLOW}"
         echo -e "Scan Types:"
@@ -80,7 +80,7 @@ usage() {
 }
 
 header() {
-        echo -e ""
+        echo
 
         if [ ${TYPE} = "All" ]; then
                 echo -e "${YELLOW}Running all scans on ${HOST}"
@@ -107,8 +107,8 @@ header() {
                 echo -e "${NC}"
         fi
 
-        echo -e ""
-        echo -e ""
+        echo
+        echo
 }
 
 assignPorts() {
@@ -214,9 +214,9 @@ quickScan() {
         nmapProgressBar "${nmapType} -T4 --max-retries 1 --max-scan-delay 20 --defeat-rst-ratelimit --open -oN nmap/Quick_${HOST}.nmap ${HOST} ${DNSSTRING}"
         assignPorts "${HOST}"
 
-        echo -e ""
-        echo -e ""
-        echo -e ""
+        echo
+        echo
+        echo
 }
 
 basicScan() {
@@ -240,9 +240,9 @@ basicScan() {
                 fi
         fi
 
-        echo -e ""
-        echo -e ""
-        echo -e ""
+        echo
+        echo
+        echo
 }
 
 UDPScan() {
@@ -252,15 +252,15 @@ UDPScan() {
         if [ "${USER}" != 'root' ]; then
                 echo "UDP needs to be run as root, running with sudo..."
                 sudo -v
-                echo ""
+                echo
         fi
 
         nmapProgressBar "sudo ${nmapType} -sU --max-retries 1 --open -oN nmap/UDP_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
         assignPorts "${HOST}"
 
         if [ -n "${udpPorts}" ]; then
-                echo ""
-                echo ""
+                echo
+                echo
                 echo -e "${YELLOW}Making a script scan on UDP ports: $(echo "${udpPorts}" | sed 's/,/, /g')"
                 echo -e "${NC}"
                 if [ -f /usr/share/nmap/scripts/vulners.nse ]; then
@@ -269,15 +269,15 @@ UDPScan() {
                         nmapProgressBar "${nmapType} -sCVU -p${udpPorts} -oN nmap/UDP_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
                 fi
         else
-                echo ""
-                echo ""
+                echo
+                echo
                 echo -e "${YELLOW}No UDP ports are open"
                 echo -e "${NC}"
         fi
 
-        echo -e ""
-        echo -e ""
-        echo -e ""
+        echo
+        echo
+        echo
 }
 
 fullScan() {
@@ -288,8 +288,8 @@ fullScan() {
         assignPorts "${HOST}"
 
         if [ -z "${basicPorts}" ]; then
-                echo ""
-                echo ""
+                echo
+                echo
                 echo -e "${YELLOW}Making a script scan on all ports"
                 echo -e "${NC}"
                 nmapProgressBar "${nmapType} -sCV -p${allPorts} -oN nmap/Full_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
@@ -297,14 +297,14 @@ fullScan() {
         else
                 cmpPorts "${HOST}"
                 if [ -z "${extraPorts}" ]; then
-                        echo ""
-                        echo ""
+                        echo
+                        echo
                         allPorts=""
                         echo -e "${YELLOW}No new ports"
                         echo -e "${NC}"
                 else
-                        echo ""
-                        echo ""
+                        echo
+                        echo
                         echo -e "${YELLOW}Making a script scan on extra ports: $(echo "${extraPorts}" | sed 's/,/, /g')"
                         echo -e "${NC}"
                         nmapProgressBar "${nmapType} -sCV -p${extraPorts} -oN nmap/Full_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
@@ -312,9 +312,9 @@ fullScan() {
                 fi
         fi
 
-        echo -e ""
-        echo -e ""
-        echo -e ""
+        echo
+        echo
+        echo
 }
 
 vulnsScan() {
@@ -339,17 +339,17 @@ vulnsScan() {
                 echo -e "${YELLOW}Running CVE scan on ${portType} ports"
                 echo -e "${NC}"
                 nmapProgressBar "${nmapType} -sV --script vulners --script-args mincvss=7.0 -p${ports} -oN nmap/CVEs_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
-                echo ""
+                echo
         fi
 
-        echo ""
+        echo
         echo -e "${YELLOW}Running Vuln scan on ${portType} ports"
         echo -e "${YELLOW}This may take a while, depending on the number of detected services.."
         echo -e "${NC}"
         nmapProgressBar "${nmapType} -sV --script vuln -p${ports} -oN nmap/Vulns_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
-        echo -e ""
-        echo -e ""
-        echo -e ""
+        echo
+        echo
+        echo
 }
 
 recon() {
@@ -396,9 +396,9 @@ recon() {
                                 reconCommand="!"
                         elif [ "${reconCommand}" = "Skip" ] || [ "${reconCommand}" = "!" ]; then
                                 reconCommand="!"
-                                echo -e ""
-                                echo -e ""
-                                echo -e ""
+                                echo
+                                echo
+                                echo
                         else
                                 echo -e "${NC}"
                                 echo -e "${RED}Incorrect choice!"
@@ -452,7 +452,7 @@ reconRecommend() {
                                 extensions=$(echo 'index' >./index && gobuster dir -w ./index -t 30 -qnkx '.asp,.aspx,.html,.jsp,.php' -s '200,302' -u ${urlType}${HOST}:${port} 2>/dev/null | awk -F 'index' {'print $2'} | tr '\n' ',' | head -c-1 && rm ./index)
                                 echo "gobuster dir -w /usr/share/wordlists/dirb/common.txt -t 30 -elkx '${extensions}' -u ${urlType}${HOST}:${port} -o recon/gobuster_${HOST}_${port}.txt"
                         fi
-                        echo ""
+                        echo
                 fi
         done
 
@@ -480,7 +480,7 @@ reconRecommend() {
                 echo -e "${YELLOW}SMTP Recon:"
                 echo -e "${NC}"
                 echo "smtp-user-enum -U /usr/share/wordlists/metasploit/unix_users.txt -t ${HOST} | tee recon/smtp_user_enum_${HOST}.txt"
-                echo ""
+                echo
         fi
 
         if echo "${file}" | grep -q "445/tcp"; then
@@ -494,13 +494,13 @@ reconRecommend() {
                 elif [ ${osType} = "Linux" ]; then
                         echo "enum4linux -a ${HOST} | tee recon/enum4linux_${HOST}.txt"
                 fi
-                echo ""
+                echo
         elif echo "${file}" | grep -q "139/tcp" && [ ${osType} = "Linux" ]; then
                 echo -e "${NC}"
                 echo -e "${YELLOW}SMB Recon:"
                 echo -e "${NC}"
                 echo "enum4linux -a ${HOST} | tee recon/enum4linux_${HOST}.txt"
-                echo ""
+                echo
         fi
 
         if [ -f nmap/UDP_Extra_"${HOST}".nmap ] && grep -q "161/udp.*open" nmap/UDP_Extra_"${HOST}".nmap; then
@@ -509,7 +509,7 @@ reconRecommend() {
                 echo -e "${NC}"
                 echo "snmp-check ${HOST} -c public | tee recon/snmpcheck_${HOST}.txt"
                 echo "snmpwalk -Os -c public -v1 ${HOST} | tee recon/snmpwalk_${HOST}.txt"
-                echo ""
+                echo
         fi
 
         if echo "${file}" | grep -q "53/tcp"; then
@@ -520,7 +520,7 @@ reconRecommend() {
                 echo "dnsrecon -r ${subnet}/24 -n ${DNSSERVER} | tee recon/dnsrecon_${HOST}.txt"
                 echo "dnsrecon -r 127.0.0.0/24 -n ${DNSSERVER} | tee recon/dnsrecon-local_${HOST}.txt"
                 echo "dig -x ${HOST} @${DNSSERVER} | tee recon/dig_${HOST}.txt"
-                echo ""
+                echo
         fi
 
         if echo "${file}" | grep -q "389/tcp"; then
@@ -530,7 +530,7 @@ reconRecommend() {
                 echo "ldapsearch -x -h ${HOST} -s base | tee recon/ldapsearch_${HOST}.txt"
                 echo "ldapsearch -x -h ${HOST} -b \$(grep rootDomainNamingContext recon/ldapsearch_${HOST}.txt | cut -d ' ' -f2) | tee recon/ldapsearch_DC_${HOST}.txt"
                 echo "nmap -Pn -p 389 --script ldap-search --script-args 'ldap.username=\"\$(grep rootDomainNamingContext recon/ldapsearch_${HOST}.txt | cut -d \\" \\" -f2)\"' ${HOST} -oN recon/nmap_ldap_${HOST}.txt"
-                echo ""
+                echo
         fi
 
         if echo "${file}" | grep -q "1521/tcp"; then
@@ -539,20 +539,20 @@ reconRecommend() {
                 echo -e "${NC}"
                 echo "odat sidguesser -s ${HOST} -p 1521"
                 echo "odat passwordguesser -s ${HOST} -p 1521 -d XE --accounts-file accounts/accounts-multiple.txt"
-                echo ""
+                echo
         fi
 
         IFS=${oldIFS}
 
-        echo -e ""
-        echo -e ""
-        echo -e ""
+        echo
+        echo
+        echo
 }
 
 runRecon() {
-        echo -e ""
-        echo -e ""
-        echo -e ""
+        echo
+        echo
+        echo
         echo -e "${GREEN}---------------------Running Recon Commands----------------------"
         echo -e "${NC}"
 
@@ -584,16 +584,16 @@ runRecon() {
 
         IFS=${oldIFS}
 
-        echo -e ""
-        echo -e ""
-        echo -e ""
+        echo
+        echo
+        echo
 }
 
 footer() {
 
         echo -e "${GREEN}---------------------Finished all Nmap scans---------------------"
         echo -e "${NC}"
-        echo -e ""
+        echo
 
         if [ ${SECONDS} -gt 3600 ]; then
                 let "hours=SECONDS/3600"
@@ -607,7 +607,7 @@ footer() {
         else
                 echo -e "${YELLOW}Completed in ${SECONDS} seconds"
         fi
-        echo -e ""
+        echo
 }
 
 main() {

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -175,7 +175,7 @@ progressBar() {
 }
 
 nmapProgressBar() {
-        refreshRate="${2:-0.5}"
+        refreshRate="${2:-1}"
         outputFile="$(echo $1 | sed -e 's/.*-oN \(.*\).nmap.*/\1/').nmap"
         tmpOutputFile="${outputFile}.tmp"
         if [ ! -e "${outputFile}" ]; then

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -574,7 +574,7 @@ runRecon() {
                         echo -e "${NC}"
                         echo -e "${YELLOW}Starting ${currentScan} scan"
                         echo -e "${NC}"
-                        echo "${line}" | /bin/bash
+                        eval "${line}"
                         echo -e "${NC}"
                         echo -e "${YELLOW}Finished ${currentScan} scan"
                         echo -e "${NC}"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -375,7 +375,7 @@ recon() {
                         printf "Which commands would you like to run?${NC}\nAll (Default), ${availableRecon}Skip <!>\n\n"
                         while [ ${count} -lt ${secs} ]; do
                                 tlimit=$((secs - count))
-                                printf "\rRunning Default in (${tlimit}) s: \c\n"
+                                printf "\033[2K\rRunning Default in (${tlimit}) s: "
 
                                 # Waits 1 second for user's input - POSIX read -t
                                 reconCommand="$(sh -c '{ { sleep 1; kill -sINT $$; } & }; exec head -n 1')"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -371,7 +371,7 @@ recon() {
 
                 availableRecon="$(echo "${allRecon}" | tr " " "\n" | grep -vE $(echo "${missingTools}" | tr " " "|") | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)"
         else
-                availableRecon="$(echo "${allRecon}" | sed 's/\ /,\ /g')"
+                availableRecon="$(echo "${allRecon}" | tr "\n" " " | sed 's/\ /,\ /g')"
         fi
 
         secs=30

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -177,17 +177,17 @@ progressBar() {
         [ $(stty size | cut -d ' ' -f 2) -le 120 ] && width=50 || width=100
         fill=$(printf "%-$((width == 100 ? $2 : ($2 / 2)))s" "#")
         empty=$(printf "%-$((width - (width == 100 ? $2 : ($2 / 2))))s" " ")
-        echo -e "In progress: ${1} Scan (${3} elapsed - ${4} remaining)   "
-        echo -e "[${fill// /\#}>${empty// / }] ${2}% done   "
+        echo -e "In progress: $1 Scan ($3 elapsed - $4 remaining)   "
+        echo -e "[${fill// /\#}>${empty// / }] $2% done   "
         echo -ne "\e[2A"
 }
 
 nmapProgressBar() {
         refreshRate=${2:-"0.5"}
-        outputFile=$(echo ${1} | sed -e 's/.*-oN \(.*\).nmap.*/\1/').nmap
+        outputFile=$(echo $1 | sed -e 's/.*-oN \(.*\).nmap.*/\1/').nmap
         tmpOutputFile=${outputFile}.tmp
-                ${1} --stats-every ${refreshRate}s >${tmpOutputFile} 2>&1 &
         if [ ! -e ${outputFile} ]; then
+                $1 --stats-every ${refreshRate}s >${tmpOutputFile} 2>&1 &
         fi
 
         while { [ ! -e ${outputFile} ] || ! grep -q "Nmap done at" ${outputFile}; } && { [ ! -e ${tmpOutputFile} ] || ! grep -i -q "quitting" ${tmpOutputFile}; }; do

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -11,7 +11,7 @@ SECONDS=0
 while [ $# -gt 0 ]; do
         key="$1"
 
-        case ${key} in
+        case "${key}" in
         -H | --host)
                 HOST="$2"
                 shift
@@ -82,16 +82,16 @@ usage() {
 header() {
         echo
 
-        if [ ${TYPE} = "All" ]; then
+        if [ "${TYPE}" = "All" ]; then
                 echo -e "${YELLOW}Running all scans on ${HOST}"
         else
                 echo -e "${YELLOW}Running a ${TYPE} scan on ${HOST}"
         fi
 
-        subnet=$(echo ${HOST} | cut -d "." -f 1,2,3)".0"
+        subnet="$(echo "${HOST}" | cut -d "." -f 1,2,3).0"
 
-        checkPing=$(checkPing ${HOST})
-        nmapType=$(echo "${checkPing}" | head -n 1)
+        checkPing="$(checkPing "${HOST}")"
+        nmapType="$(echo "${checkPing}" | head -n 1)"
 
         if [ "${nmapType}" != "nmap" ]; then
                 echo -e "${NC}"
@@ -99,7 +99,7 @@ header() {
                 echo -e "${NC}"
         fi
 
-        ttl=$(echo "${checkPing}" | tail -n 1)
+        ttl="$(echo "${checkPing}" | tail -n 1)"
         if [ "${ttl}" != "nmap -Pn" ]; then
                 osType="$(checkOS "${ttl}")"
                 echo -e "${NC}"
@@ -112,20 +112,20 @@ header() {
 }
 
 assignPorts() {
-        if [ -f nmap/Quick_${HOST}.nmap ]; then
-                basicPorts=$(grep open nmap/Quick_${HOST}.nmap | cut -d " " -f 1 | cut -d "/" -f 1 | tr "\n" "," | cut -c3- | head -c-2)
+        if [ -f "nmap/Quick_${HOST}.nmap" ]; then
+                basicPorts="$(grep open "nmap/Quick_${HOST}.nmap" | cut -d " " -f 1 | cut -d "/" -f 1 | tr "\n" "," | cut -c3- | head -c-2)"
         fi
 
-        if [ -f nmap/Full_${HOST}.nmap ]; then
-                if [ -f nmap/Quick_${HOST}.nmap ]; then
-                        allPorts=$(cat nmap/Quick_"${HOST}".nmap nmap/Full_"${HOST}".nmap | grep open | cut -d " " -f 1 | cut -d "/" -f 1 | tr "\n" "," | cut -c3- | head -c-1)
+        if [ -f "nmap/Full_${HOST}.nmap" ]; then
+                if [ -f "nmap/Quick_${HOST}.nmap" ]; then
+                        allPorts="$(cat "nmap/Quick_${HOST}.nmap" "nmap/Full_${HOST}.nmap" | grep open | cut -d " " -f 1 | cut -d "/" -f 1 | tr "\n" "," | cut -c3- | head -c-1)"
                 else
-                        allPorts=$(grep open nmap/Full_"${HOST}".nmap | cut -d " " -f 1 | cut -d "/" -f 1 | tr "\n" "," | head -c-1)
+                        allPorts="$(grep open "nmap/Full_${HOST}.nmap" | cut -d " " -f 1 | cut -d "/" -f 1 | tr "\n" "," | head -c-1)"
                 fi
         fi
 
-        if [ -f nmap/UDP_"${HOST}".nmap ]; then
-                udpPorts=$(grep "open " nmap/UDP_"${HOST}".nmap | cut -d " " -f 1 | cut -d "/" -f 1 | tr "\n" "," | cut -c3- | head -c-2)
+        if [ -f "nmap/UDP_${HOST}.nmap" ]; then
+                udpPorts="$(grep "open " "nmap/UDP_${HOST}.nmap" | cut -d " " -f 1 | cut -d "/" -f 1 | tr "\n" "," | cut -c3- | head -c-2)"
                 if [ "${udpPorts}" = "Al" ]; then
                         udpPorts=""
                 fi
@@ -133,15 +133,15 @@ assignPorts() {
 }
 
 checkPing() {
-        pingTest=$(ping -c 1 -W 3 "${HOST}" | grep ttl)
+        pingTest="$(ping -c 1 -W 3 "${HOST}" | grep ttl)"
         if [ -z "${pingTest}" ]; then
                 echo "nmap -Pn"
         else
                 echo "nmap"
                 if [[ "${HOST}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                        ttl=$(echo "${pingTest}" | cut -d " " -f 6 | cut -d "=" -f 2)
+                        ttl="$(echo "${pingTest}" | cut -d " " -f 6 | cut -d "=" -f 2)"
                 else
-                        ttl=$(echo "${pingTest}" | cut -d " " -f 7 | cut -d "=" -f 2)
+                        ttl="$(echo "${pingTest}" | cut -d " " -f 7 | cut -d "=" -f 2)"
                 fi
                 echo "${ttl}"
         fi
@@ -157,54 +157,54 @@ checkOS() {
 }
 
 cmpPorts() {
-        oldIFS=${IFS}
+        oldIFS="${IFS}"
         IFS=','
-        touch nmap/cmpPorts_"${HOST}".txt
+        touch "nmap/cmpPorts_${HOST}.txt"
 
         for i in ${allPorts}; do
-                if ! [[ "${i}" =~ ^($(echo "${basicPorts}" | sed 's/,/\|/g'))$ ]]; then
-                        echo -n "${i}," >>nmap/cmpPorts_"${HOST}".txt
+                if ! [[ "${i}" =~ ^("$(echo "${basicPorts}" | sed 's/,/\|/g')")$ ]]; then
+                        echo -n "${i}," >> "nmap/cmpPorts_${HOST}.txt"
                 fi
         done
 
-        extraPorts=$(tr "\n" "," <nmap/cmpPorts_"${HOST}".txt | head -c-1)
-        rm nmap/cmpPorts_"${HOST}".txt
-        IFS=${oldIFS}
+        extraPorts="$(tr "\n" "," < "nmap/cmpPorts_${HOST}.txt" | head -c-1)"
+        rm "nmap/cmpPorts_${HOST}.txt"
+        IFS="${oldIFS}"
 }
 
 progressBar() {
         [ -z "${2##*[!0-9]*}" ] && return 1
-        [ $(stty size | cut -d ' ' -f 2) -le 120 ] && width=50 || width=100
-        fill=$(printf "%-$((width == 100 ? $2 : ($2 / 2)))s" "#")
-        empty=$(printf "%-$((width - (width == 100 ? $2 : ($2 / 2))))s" " ")
+        [ "$(stty size | cut -d ' ' -f 2)" -le 120 ] && width=50 || width=100
+        fill="$(printf "%-$((width == 100 ? $2 : ($2 / 2)))s" "#")"
+        empty="$(printf "%-$((width - (width == 100 ? $2 : ($2 / 2))))s" " ")"
         echo -e "In progress: $1 Scan ($3 elapsed - $4 remaining)   "
         echo -e "[${fill// /\#}>${empty// / }] $2% done   "
         echo -ne "\e[2A"
 }
 
 nmapProgressBar() {
-        refreshRate=${2:-"0.5"}
-        outputFile=$(echo $1 | sed -e 's/.*-oN \(.*\).nmap.*/\1/').nmap
-        tmpOutputFile=${outputFile}.tmp
-        if [ ! -e ${outputFile} ]; then
-                $1 --stats-every ${refreshRate}s >${tmpOutputFile} 2>&1 &
+        refreshRate="${2:-0.5}"
+        outputFile="$(echo $1 | sed -e 's/.*-oN \(.*\).nmap.*/\1/').nmap"
+        tmpOutputFile="${outputFile}.tmp"
+        if [ ! -e "${outputFile}" ]; then
+                $1 --stats-every "${refreshRate}s" > "${tmpOutputFile}" 2>&1 &
         fi
 
-        while { [ ! -e ${outputFile} ] || ! grep -q "Nmap done at" ${outputFile}; } && { [ ! -e ${tmpOutputFile} ] || ! grep -i -q "quitting" ${tmpOutputFile}; }; do
-                scanType=$(tail -n 2 ${tmpOutputFile} | sed -ne '/elapsed/{s/.*undergoing \(.*\) Scan.*/\1/p}')
-                percent=$(tail -n 2 ${tmpOutputFile} | sed -ne '/% done/{s/.*About \(.*\)\..*% done.*/\1/p}')
-                elapsed=$(tail -n 2 ${tmpOutputFile} | sed -ne '/elapsed/{s/Stats: \(.*\) elapsed.*/\1/p}')
-                remaining=$(tail -n 2 ${tmpOutputFile} | sed -ne '/remaining/{s/.* (\(.*\) remaining.*/\1/p}')
-                progressBar ${scanType:-"No"} ${percent:-0} ${elapsed:-"0:00:00"} ${remaining:-"0:00:00"}
-                sleep ${refreshRate}
+        while { [ ! -e "${outputFile}" ] || ! grep -q "Nmap done at" "${outputFile}"; } && { [ ! -e "${tmpOutputFile}" ] || ! grep -i -q "quitting" "${tmpOutputFile}"; }; do
+                scanType="$(tail -n 2 "${tmpOutputFile}" | sed -ne '/elapsed/{s/.*undergoing \(.*\) Scan.*/\1/p}')"
+                percent="$(tail -n 2 "${tmpOutputFile}" | sed -ne '/% done/{s/.*About \(.*\)\..*% done.*/\1/p}')"
+                elapsed="$(tail -n 2 "${tmpOutputFile}" | sed -ne '/elapsed/{s/Stats: \(.*\) elapsed.*/\1/p}')"
+                remaining="$(tail -n 2 "${tmpOutputFile}" | sed -ne '/remaining/{s/.* (\(.*\) remaining.*/\1/p}')"
+                progressBar "${scanType:-No}" "${percent:-0}" "${elapsed:-0:00:00}" "${remaining:-0:00:00}"
+                sleep "${refreshRate}"
         done
         echo -e "\033[0K\r\n\033[0K\r"
-        if [ -e ${outputFile} ]; then
-                sed -n '/PORT.*STATE.*SERVICE/,/Nmap done at.*/p' ${outputFile} | head -n-2
+        if [ -e "${outputFile}" ]; then
+                sed -n '/PORT.*STATE.*SERVICE/,/Nmap done at.*/p' "${outputFile}" | head -n-2
         else
-                cat ${tmpOutputFile}
+                cat "${tmpOutputFile}"
         fi
-        rm -f ${tmpOutputFile}
+        rm -f "${tmpOutputFile}"
 }
 
 quickScan() {
@@ -229,8 +229,8 @@ basicScan() {
                 nmapProgressBar "${nmapType} -sCV -p${basicPorts} -oN nmap/Basic_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
         fi
 
-        if [ -f nmap/Basic_"${HOST}".nmap ] && grep -q "Service Info: OS:" nmap/Basic_"${HOST}".nmap; then
-                serviceOS=$(grep "Service Info: OS:" nmap/Basic_"${HOST}".nmap | cut -d ":" -f 3 | cut -c2- | cut -d ";" -f 1 | head -c-1)
+        if [ -f "nmap/Basic_${HOST}.nmap" ] && grep -q "Service Info: OS:" "nmap/Basic_${HOST}.nmap"; then
+                serviceOS="$(grep "Service Info: OS:" "nmap/Basic_${HOST}.nmap" | cut -d ":" -f 3 | cut -c2- | cut -d ";" -f 1 | head -c-1)"
                 if [ "${osType}" != "${serviceOS}" ]; then
                         osType="${serviceOS}"
                         echo -e "${NC}"
@@ -354,11 +354,11 @@ vulnsScan() {
 
 recon() {
 
-        reconRecommend "${HOST}" | tee nmap/Recon_"${HOST}".nmap
-        allRecon=$(grep "${HOST}" nmap/Recon_"${HOST}".nmap | cut -d " " -f 1 | sort -u)
+        reconRecommend "${HOST}" | tee "nmap/Recon_${HOST}.nmap"
+        allRecon="$(grep "${HOST}" "nmap/Recon_${HOST}.nmap" | cut -d " " -f 1 | sort -u)"
 
         for tool in ${allRecon}; do
-                if ! type ${tool} 2>/dev/null | grep -q bin; then
+                if ! type "${tool}" 2>/dev/null | grep -q bin; then
                         missingTools="${missingTools} ${tool}"
                 fi
         done
@@ -369,9 +369,9 @@ recon() {
                 echo -e "${YELLOW}sudo apt install${missingTools} -y"
                 echo -e "${NC}\n"
 
-                availableRecon=$(echo ${allRecon} | tr " " "\n" | grep -vE $(echo ${missingTools} | tr " " "|") | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)
+                availableRecon="$(echo "${allRecon}" | tr " " "\n" | grep -vE $(echo "${missingTools}" | tr " " "|") | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)"
         else
-                availableRecon=$(echo ${allRecon} | sed 's/\ /,\ /g')
+                availableRecon="$(echo "${allRecon}" | sed 's/\ /,\ /g')"
         fi
 
         secs=30
@@ -391,8 +391,8 @@ recon() {
                         if [ "${reconCommand}" = "All" ] || [ -z "${reconCommand}" ]; then
                                 runRecon "${HOST}" "All"
                                 reconCommand="!"
-                        elif [[ "${reconCommand}" =~ ^($(echo "${availableRecon}" | tr ", " "|"))$ ]]; then
-                                runRecon "${HOST}" ${reconCommand}
+                        elif [[ "${reconCommand}" =~ ^("$(echo "${availableRecon}" | tr ", " "|")")$ ]]; then
+                                runRecon "${HOST}" "${reconCommand}"
                                 reconCommand="!"
                         elif [ "${reconCommand}" = "Skip" ] || [ "${reconCommand}" = "!" ]; then
                                 reconCommand="!"
@@ -416,15 +416,15 @@ reconRecommend() {
         echo -e "${GREEN}---------------------Recon Recommendations----------------------"
         echo -e "${NC}"
 
-        oldIFS=${IFS}
+        oldIFS="${IFS}"
         IFS=$'\n'
 
-        if [ -f nmap/Full_Extra_"${HOST}".nmap ]; then
+        if [ -f "nmap/Full_Extra_${HOST}.nmap" ]; then
                 ports="${allPorts}"
-                file=$(cat nmap/Basic_"${HOST}".nmap nmap/Full_Extra_"${HOST}".nmap | grep "open" | sort -u)
+                file="$(cat "nmap/Basic_${HOST}.nmap" "nmap/Full_Extra_${HOST}.nmap" | grep "open" | sort -u)"
         else
                 ports="${basicPorts}"
-                file=$(grep "open" nmap/Basic_"${HOST}".nmap)
+                file="$(grep "open" "nmap/Basic_${HOST}.nmap")"
 
         fi
 
@@ -436,40 +436,40 @@ reconRecommend() {
 
         for line in ${file}; do
                 if echo "${line}" | grep -i -q http; then
-                        port=$(echo "${line}" | cut -d "/" -f 1)
+                        port="$(echo "${line}" | cut -d "/" -f 1)"
                         if echo "${line}" | grep -q ssl/http; then
                                 urlType='https://'
-                                echo "sslscan ${HOST} | tee recon/sslscan_${HOST}_${port}.txt"
-                                echo "nikto -host ${urlType}${HOST}:${port} -ssl | tee recon/nikto_${HOST}_${port}.txt"
+                                echo "sslscan \"${HOST}\" | tee \"recon/sslscan_${HOST}_${port}.txt\""
+                                echo "nikto -host \"${urlType}${HOST}:${port}\" -ssl | tee \"recon/nikto_${HOST}_${port}.txt\""
                         else
                                 urlType='http://'
-                                echo "nikto -host ${urlType}${HOST}:${port} | tee recon/nikto_${HOST}_${port}.txt"
+                                echo "nikto -host \"${urlType}${HOST}:${port}\" | tee \"recon/nikto_${HOST}_${port}.txt\""
                         fi
                         if type ffuf | grep -q bin; then
-                                extensions=$(echo 'index' >./index && ffuf -s -w ./index:FUZZ -mc '200,302' -e '.asp,.aspx,.html,.jsp,.php' -u ${urlType}${HOST}:${port}/FUZZ 2>/dev/null | awk -F 'index' {'print $2'} | tr '\n' ',' | head -c-1 && rm ./index)
-                                echo "ffuf -ic -w /usr/share/wordlists/dirb/common.txt -e '${extensions}' -u ${urlType}${HOST}:${port}/FUZZ | tee recon/ffuf_${HOST}_${port}.txt"
+                                extensions="$(echo 'index' >./index && ffuf -s -w ./index:FUZZ -mc '200,302' -e '.asp,.aspx,.html,.jsp,.php' -u "${urlType}${HOST}:${port}/FUZZ" 2>/dev/null | awk -F 'index' '{print $2}' | tr '\n' ',' | head -c-1 && rm ./index)"
+                                echo "ffuf -ic -w /usr/share/wordlists/dirb/common.txt -e '${extensions}' -u \"${urlType}${HOST}:${port}/FUZZ\" | tee \"recon/ffuf_${HOST}_${port}.txt\""
                         else
-                                extensions=$(echo 'index' >./index && gobuster dir -w ./index -t 30 -qnkx '.asp,.aspx,.html,.jsp,.php' -s '200,302' -u ${urlType}${HOST}:${port} 2>/dev/null | awk -F 'index' {'print $2'} | tr '\n' ',' | head -c-1 && rm ./index)
-                                echo "gobuster dir -w /usr/share/wordlists/dirb/common.txt -t 30 -elkx '${extensions}' -u ${urlType}${HOST}:${port} -o recon/gobuster_${HOST}_${port}.txt"
+                                extensions="$(echo 'index' >./index && gobuster dir -w ./index -t 30 -qnkx '.asp,.aspx,.html,.jsp,.php' -s '200,302' -u "${urlType}${HOST}:${port}" 2>/dev/null | awk -F 'index' '{print $2}' | tr '\n' ',' | head -c-1 && rm ./index)"
+                                echo "gobuster dir -w /usr/share/wordlists/dirb/common.txt -t 30 -elkx '${extensions}' -u \"${urlType}${HOST}:${port}\" -o \"recon/gobuster_${HOST}_${port}.txt\""
                         fi
                         echo
                 fi
         done
 
-        if [ -f nmap/Basic_"${HOST}".nmap ]; then
-                cms=$(grep http-generator nmap/Basic_"${HOST}".nmap | cut -d " " -f 2)
+        if [ -f "nmap/Basic_${HOST}.nmap" ]; then
+                cms="$(grep http-generator "nmap/Basic_${HOST}.nmap" | cut -d " " -f 2)"
                 if [ -n "${cms}" ]; then
                         for line in ${cms}; do
-                                port=$(grep "${line}" -B1 nmap/Basic_"${HOST}".nmap | grep "open" | cut -d "/" -f 1)
+                                port="$(grep "${line}" -B1 "nmap/Basic_${HOST}.nmap" | grep "open" | cut -d "/" -f 1)"
                                 if [[ "${cms}" =~ ^(Joomla|WordPress|Drupal)$ ]]; then
                                         echo -e "${NC}"
                                         echo -e "${YELLOW}CMS Recon:"
                                         echo -e "${NC}"
                                 fi
                                 case "${cms}" in
-                                Joomla!) echo "joomscan --url ${HOST}:${port} | tee recon/joomscan_${HOST}_${port}.txt" ;;
-                                WordPress) echo "wpscan --url ${HOST}:${port} --enumerate p | tee recon/wpscan_${HOST}_${port}.txt" ;;
-                                Drupal) echo "droopescan scan drupal -u ${HOST}:${port} | tee recon/droopescan_${HOST}_${port}.txt" ;;
+                                Joomla!) echo "joomscan --url \"${HOST}:${port}\" | tee \"recon/joomscan_${HOST}_${port}.txt\"" ;;
+                                WordPress) echo "wpscan --url \"${HOST}:${port}\" --enumerate p | tee \"recon/wpscan_${HOST}_${port}.txt\"" ;;
+                                Drupal) echo "droopescan scan drupal -u \"${HOST}:${port}\" | tee \"recon/droopescan_${HOST}_${port}.txt\"" ;;
                                 esac
                         done
                 fi
@@ -479,7 +479,7 @@ reconRecommend() {
                 echo -e "${NC}"
                 echo -e "${YELLOW}SMTP Recon:"
                 echo -e "${NC}"
-                echo "smtp-user-enum -U /usr/share/wordlists/metasploit/unix_users.txt -t ${HOST} | tee recon/smtp_user_enum_${HOST}.txt"
+                echo "smtp-user-enum -U /usr/share/wordlists/metasploit/unix_users.txt -t \"${HOST}\" | tee \"recon/smtp_user_enum_${HOST}.txt\""
                 echo
         fi
 
@@ -487,28 +487,28 @@ reconRecommend() {
                 echo -e "${NC}"
                 echo -e "${YELLOW}SMB Recon:"
                 echo -e "${NC}"
-                echo "smbmap -H ${HOST} | tee recon/smbmap_${HOST}.txt"
-                echo "smbclient -L \"//${HOST}/\" -U \"guest\"% | tee recon/smbclient_${HOST}.txt"
-                if [ ${osType} = "Windows" ]; then
-                        echo "nmap -Pn -p445 --script vuln -oN recon/SMB_vulns_${HOST}.txt ${HOST}"
-                elif [ ${osType} = "Linux" ]; then
-                        echo "enum4linux -a ${HOST} | tee recon/enum4linux_${HOST}.txt"
+                echo "smbmap -H \"${HOST}\" | tee \"recon/smbmap_${HOST}.txt\""
+                echo "smbclient -L \"//${HOST}/\" -U \"guest\"% | tee \"recon/smbclient_${HOST}.txt\""
+                if [ "${osType}" = "Windows" ]; then
+                        echo "nmap -Pn -p445 --script vuln -oN \"recon/SMB_vulns_${HOST}.txt\" \"${HOST}\""
+                elif [ "${osType}" = "Linux" ]; then
+                        echo "enum4linux -a \"${HOST}\" | tee \"recon/enum4linux_${HOST}.txt\""
                 fi
                 echo
-        elif echo "${file}" | grep -q "139/tcp" && [ ${osType} = "Linux" ]; then
+        elif echo "${file}" | grep -q "139/tcp" && [ "${osType}" = "Linux" ]; then
                 echo -e "${NC}"
                 echo -e "${YELLOW}SMB Recon:"
                 echo -e "${NC}"
-                echo "enum4linux -a ${HOST} | tee recon/enum4linux_${HOST}.txt"
+                echo "enum4linux -a \"${HOST}\" | tee \"recon/enum4linux_${HOST}.txt\""
                 echo
         fi
 
-        if [ -f nmap/UDP_Extra_"${HOST}".nmap ] && grep -q "161/udp.*open" nmap/UDP_Extra_"${HOST}".nmap; then
+        if [ -f "nmap/UDP_Extra_${HOST}.nmap" ] && grep -q "161/udp.*open" "nmap/UDP_Extra_${HOST}.nmap"; then
                 echo -e "${NC}"
                 echo -e "${YELLOW}SNMP Recon:"
                 echo -e "${NC}"
-                echo "snmp-check ${HOST} -c public | tee recon/snmpcheck_${HOST}.txt"
-                echo "snmpwalk -Os -c public -v1 ${HOST} | tee recon/snmpwalk_${HOST}.txt"
+                echo "snmp-check \"${HOST}\" -c public | tee \"recon/snmpcheck_${HOST}.txt\""
+                echo "snmpwalk -Os -c public -v1 \"${HOST}\" | tee \"recon/snmpwalk_${HOST}.txt\""
                 echo
         fi
 
@@ -516,10 +516,10 @@ reconRecommend() {
                 echo -e "${NC}"
                 echo -e "${YELLOW}DNS Recon:"
                 echo -e "${NC}"
-                echo "host -l ${HOST} ${DNSSERVER} | tee recon/hostname_${HOST}.txt"
-                echo "dnsrecon -r ${subnet}/24 -n ${DNSSERVER} | tee recon/dnsrecon_${HOST}.txt"
-                echo "dnsrecon -r 127.0.0.0/24 -n ${DNSSERVER} | tee recon/dnsrecon-local_${HOST}.txt"
-                echo "dig -x ${HOST} @${DNSSERVER} | tee recon/dig_${HOST}.txt"
+                echo "host -l \"${HOST}\" \"${DNSSERVER}\" | tee \"recon/hostname_${HOST}.txt\""
+                echo "dnsrecon -r \"${subnet}/24\" -n \"${DNSSERVER}\" | tee \"recon/dnsrecon_${HOST}.txt\""
+                echo "dnsrecon -r 127.0.0.0/24 -n \"${DNSSERVER}\" | tee \"recon/dnsrecon-local_${HOST}.txt\""
+                echo "dig -x \"${HOST}\" @${DNSSERVER} | tee \"recon/dig_${HOST}.txt\""
                 echo
         fi
 
@@ -527,9 +527,9 @@ reconRecommend() {
                 echo -e "${NC}"
                 echo -e "${YELLOW}ldap Recon:"
                 echo -e "${NC}"
-                echo "ldapsearch -x -h ${HOST} -s base | tee recon/ldapsearch_${HOST}.txt"
-                echo "ldapsearch -x -h ${HOST} -b \$(grep rootDomainNamingContext recon/ldapsearch_${HOST}.txt | cut -d ' ' -f2) | tee recon/ldapsearch_DC_${HOST}.txt"
-                echo "nmap -Pn -p 389 --script ldap-search --script-args 'ldap.username=\"\$(grep rootDomainNamingContext recon/ldapsearch_${HOST}.txt | cut -d \\" \\" -f2)\"' ${HOST} -oN recon/nmap_ldap_${HOST}.txt"
+                echo "ldapsearch -x -h \"${HOST}\" -s base | tee \"recon/ldapsearch_${HOST}.txt\""
+                echo "ldapsearch -x -h \"${HOST}\" -b \"\$(grep rootDomainNamingContext \"recon/ldapsearch_${HOST}.txt\" | cut -d ' ' -f2)\" | tee \"recon/ldapsearch_DC_${HOST}.txt\""
+                echo "nmap -Pn -p 389 --script ldap-search --script-args 'ldap.username=\"\$(grep rootDomainNamingContext \"recon/ldapsearch_${HOST}.txt\" | cut -d \\" \\" -f2)\"' \"${HOST}\" -oN \"recon/nmap_ldap_${HOST}.txt\""
                 echo
         fi
 
@@ -537,12 +537,12 @@ reconRecommend() {
                 echo -e "${NC}"
                 echo -e "${YELLOW}Oracle Recon:"
                 echo -e "${NC}"
-                echo "odat sidguesser -s ${HOST} -p 1521"
-                echo "odat passwordguesser -s ${HOST} -p 1521 -d XE --accounts-file accounts/accounts-multiple.txt"
+                echo "odat sidguesser -s \"${HOST}\" -p 1521"
+                echo "odat passwordguesser -s \"${HOST}\" -p 1521 -d XE --accounts-file accounts/accounts-multiple.txt"
                 echo
         fi
 
-        IFS=${oldIFS}
+        IFS="${oldIFS}"
 
         echo
         echo
@@ -556,20 +556,20 @@ runRecon() {
         echo -e "${GREEN}---------------------Running Recon Commands----------------------"
         echo -e "${NC}"
 
-        oldIFS=${IFS}
+        oldIFS="${IFS}"
         IFS=$'\n'
 
         mkdir -p recon/
 
         if [ "$2" = "All" ]; then
-                reconCommands=$(grep "${HOST}" nmap/Recon_"${HOST}".nmap)
+                reconCommands="$(grep "${HOST}" "nmap/Recon_${HOST}.nmap")"
         else
-                reconCommands=$(grep "${HOST}" nmap/Recon_"${HOST}".nmap | grep "$2")
+                reconCommands="$(grep "${HOST}" "nmap/Recon_${HOST}.nmap" | grep "$2")"
         fi
 
         for line in ${reconCommands}; do
-                currentScan=$(echo "${line}" | cut -d " " -f 1 | sort -u | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)
-                fileName=$(echo "${line}" | awk -F "recon/" '{print ${TYPE}}' | head -c-1)
+                currentScan="$(echo "${line}" | cut -d " " -f 1 | sort -u | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)"
+                fileName="$(echo "${line}" | awk -F "recon/" "{print ${TYPE}}" | head -c-1)"
                 if [ -n "${fileName}" ] && [ ! -f recon/"${fileName}" ]; then
                         echo -e "${NC}"
                         echo -e "${YELLOW}Starting ${currentScan} scan"
@@ -582,7 +582,7 @@ runRecon() {
                 fi
         done
 
-        IFS=${oldIFS}
+        IFS="${oldIFS}"
 
         echo
         echo
@@ -618,18 +618,18 @@ main() {
         case "${TYPE}" in
         Quick | quick) quickScan "${HOST}" ;;
         Basic | basic)
-                [ ! -f nmap/Quick_"${HOST}".nmap ] && quickScan "${HOST}"
+                [ ! -f "nmap/Quick_${HOST}.nmap" ] && quickScan "${HOST}"
                 basicScan "${HOST}"
                 ;;
         UDP | udp) UDPScan "${HOST}" ;;
         Full | full) fullScan "${HOST}" ;;
         Vulns | vulns)
-                [ ! -f nmap/Quick_"${HOST}".nmap ] && quickScan "${HOST}"
+                [ ! -f "nmap/Quick_${HOST}.nmap" ] && quickScan "${HOST}"
                 vulnsScan "${HOST}"
                 ;;
         Recon | recon)
-                [ ! -f nmap/Quick_"${HOST}".nmap ] && quickScan "${HOST}"
-                [ ! -f nmap/Basic_"${HOST}".nmap ] && basicScan "${HOST}"
+                [ ! -f "nmap/Quick_${HOST}.nmap" ] && quickScan "${HOST}"
+                [ ! -f "nmap/Basic_${HOST}.nmap" ] && basicScan "${HOST}"
                 recon "${HOST}"
                 ;;
         All | all)
@@ -649,7 +649,7 @@ if [ -z "${TYPE}" ] || [ -z "${HOST}" ]; then
         usage
 fi
 
-if ! [[ ${HOST} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] && ! [[ ${HOST} =~ ^([A-Za-z0-9-]{1,63}\.)+[A-Za-z]{2,6}$ ]]; then
+if ! [[ "${HOST}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] && ! [[ "${HOST}" =~ ^([A-Za-z0-9-]{1,63}\.)+[A-Za-z]{2,6}$ ]]; then
         echo -e "${RED}"
         echo -e "${RED}Invalid IP or URL!"
         echo -e "${RED}"
@@ -658,7 +658,7 @@ fi
 
 if [[ "${TYPE}" =~ ^(Quick|Basic|UDP|Full|Vulns|Recon|All|quick|basic|udp|full|vulns|recon|all)$ ]]; then
         mkdir -p "${OUTPUTDIR}" && cd "${OUTPUTDIR}" && mkdir -p nmap/ || usage
-        main | tee nmapAutomator_"${HOST}"_"${TYPE}".txt
+        main | tee "nmapAutomator_${HOST}_${TYPE}.txt"
 else
         echo -e "${RED}"
         echo -e "${RED}Invalid Type!"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -345,6 +345,9 @@ vulnsScan() {
 }
 
 recon() {
+        oldIFS="${IFS}"
+        IFS="
+"
 
         reconRecommend "${HOST}" | tee "nmap/Recon_${HOST}.nmap"
         allRecon="$(grep "${HOST}" "nmap/Recon_${HOST}.nmap" | cut -d " " -f 1 | sort | uniq)"
@@ -404,6 +407,7 @@ recon() {
                 printf "${NC}\n\n\n"
         fi
 
+        IFS="${oldIFS}"
 }
 
 reconRecommend() {

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -6,7 +6,7 @@ YELLOW='\033[0;33m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-SECONDS=0
+elapsedStart="$(date '+%H:%M:%S' | awk -F: '{print $1 * 3600 + $2 * 60 + $3}')"
 
 while [ $# -gt 0 ]; do
         key="$1"
@@ -592,17 +592,20 @@ footer() {
         printf "${GREEN}---------------------Finished all Nmap scans---------------------\n"
         printf "${NC}\n\n"
 
-        if [ ${SECONDS} -gt 3600 ]; then
-                hours=$((SECONDS / 3600))
-                minutes=$(((SECONDS % 3600) / 60))
-                seconds=$(((SECONDS % 3600) % 60))
+        elapsedEnd="$(date '+%H:%M:%S' | awk -F: '{print $1 * 3600 + $2 * 60 + $3}')"
+        elapsedSeconds=$((elapsedEnd - elapsedStart))
+
+        if [ ${elapsedSeconds} -gt 3600 ]; then
+                hours=$((elapsedSeconds / 3600))
+                minutes=$(((elapsedSeconds % 3600) / 60))
+                seconds=$(((elapsedSeconds % 3600) % 60))
                 printf "${YELLOW}Completed in ${hours} hour(s), ${minutes} minute(s) and ${seconds} second(s)\n"
-        elif [ ${SECONDS} -gt 60 ]; then
-                minutes=$(((SECONDS % 3600) / 60))
-                seconds=$(((SECONDS % 3600) % 60))
+        elif [ ${elapsedSeconds} -gt 60 ]; then
+                minutes=$(((elapsedSeconds % 3600) / 60))
+                seconds=$(((elapsedSeconds % 3600) % 60))
                 printf "${YELLOW}Completed in ${minutes} minute(s) and ${seconds} second(s)\n"
         else
-                printf "${YELLOW}Completed in ${SECONDS} seconds\n"
+                printf "${YELLOW}Completed in ${elapsedSeconds} seconds\n"
         fi
         printf "${NC}\n"
 }

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -226,7 +226,7 @@ basicScan() {
         if [ -z "${basicPorts}" ]; then
                 echo -e "${YELLOW}No ports in quick scan.. Skipping!"
         else
-                nmapProgressBar "${nmapType} -sCV -p$(echo ${basicPorts}) -oN nmap/Basic_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
+                nmapProgressBar "${nmapType} -sCV -p${basicPorts} -oN nmap/Basic_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
         fi
 
         if [ -f nmap/Basic_"${HOST}".nmap ] && grep -q "Service Info: OS:" nmap/Basic_"${HOST}".nmap; then
@@ -264,9 +264,9 @@ UDPScan() {
                 echo -e "${YELLOW}Making a script scan on UDP ports: $(echo "${udpPorts}" | sed 's/,/, /g')"
                 echo -e "${NC}"
                 if [ -f /usr/share/nmap/scripts/vulners.nse ]; then
-                        nmapProgressBar "${nmapType} -sCVU --script vulners --script-args mincvss=7.0 -p$(echo ${udpPorts}) -oN nmap/UDP_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
+                        nmapProgressBar "${nmapType} -sCVU --script vulners --script-args mincvss=7.0 -p${udpPorts} -oN nmap/UDP_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
                 else
-                        nmapProgressBar "${nmapType} -sCVU -p$(echo ${udpPorts}) -oN nmap/UDP_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
+                        nmapProgressBar "${nmapType} -sCVU -p${udpPorts} -oN nmap/UDP_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
                 fi
         else
                 echo ""
@@ -292,7 +292,7 @@ fullScan() {
                 echo ""
                 echo -e "${YELLOW}Making a script scan on all ports"
                 echo -e "${NC}"
-                nmapProgressBar "${nmapType} -sCV -p$(echo ${allPorts}) -oN nmap/Full_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
+                nmapProgressBar "${nmapType} -sCV -p${allPorts} -oN nmap/Full_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
                 assignPorts "${HOST}"
         else
                 cmpPorts "${HOST}"
@@ -570,7 +570,7 @@ runRecon() {
         for line in ${reconCommands}; do
                 currentScan=$(echo "${line}" | cut -d " " -f 1 | sort -u | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)
                 fileName=$(echo "${line}" | awk -F "recon/" '{print ${TYPE}}' | head -c-1)
-                if [ ! -z recon/$(echo "${fileName}") ] && [ ! -f recon/$(echo "${fileName}") ]; then
+                if [ ! -z recon/"${fileName}" ] && [ ! -f recon/"${fileName}" ]; then
                         echo -e "${NC}"
                         echo -e "${YELLOW}Starting ${currentScan} scan"
                         echo -e "${NC}"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -192,7 +192,7 @@ nmapProgressBar() {
         done
         printf "\033[0K\r\n\033[0K\r\n"
         if [ -e "${outputFile}" ]; then
-                sed -n '/PORT.*STATE.*SERVICE/,/^$/p' "${outputFile}"
+                sed -n '/PORT.*STATE.*SERVICE/,/^# Nmap/H;${x;s/^\n\|\n[^\n]*\n# Nmap.*//gp}' "${outputFile}"
         else
                 cat "${tmpOutputFile}"
         fi

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -376,7 +376,9 @@ recon() {
                         while [ ${count} -lt ${secs} ]; do
                                 tlimit=$((secs - count))
                                 printf "\rRunning Default in (${tlimit}) s: \c\n"
-                                read -t 1 reconCommand
+
+                                # Waits 1 second for user's input - POSIX read -t
+                                reconCommand="$(sh -c '{ { sleep 1; kill -sINT $$; } & }; exec head -n 1')"
                                 count=$((count + 1))
                                 [ -n "${reconCommand}" ] && break
                         done

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -570,7 +570,7 @@ runRecon() {
         for line in ${reconCommands}; do
                 currentScan=$(echo "${line}" | cut -d " " -f 1 | sort -u | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)
                 fileName=$(echo "${line}" | awk -F "recon/" '{print ${TYPE}}' | head -c-1)
-                if [ ! -z recon/"${fileName}" ] && [ ! -f recon/"${fileName}" ]; then
+                if [ -n "${fileName}" ] && [ ! -f recon/"${fileName}" ]; then
                         echo -e "${NC}"
                         echo -e "${YELLOW}Starting ${currentScan} scan"
                         echo -e "${NC}"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -590,8 +590,7 @@ runRecon() {
 footer() {
 
         printf "${GREEN}---------------------Finished all Nmap scans---------------------\n"
-        printf "${NC}\n"
-        echo
+        printf "${NC}\n\n"
 
         if [ ${SECONDS} -gt 3600 ]; then
                 hours=$((SECONDS / 3600))

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -369,7 +369,7 @@ recon() {
                 echo -e "${YELLOW}sudo apt install${missingTools} -y"
                 echo -e "${NC}\n"
 
-                availableRecon="$(echo "${allRecon}" | tr " " "\n" | grep -vE $(echo "${missingTools}" | tr " " "|") | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)"
+                availableRecon="$(echo "${allRecon}" | tr " " "\n" | grep -vE "$(echo "${missingTools}" | tr " " "|")" | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)"
         else
                 availableRecon="$(echo "${allRecon}" | tr "\n" " " | sed 's/\ /,\ /g')"
         fi

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -218,7 +218,7 @@ basicScan() {
         if [ -z "${basicPorts}" ]; then
                 printf "${YELLOW}No ports in quick scan.. Skipping!\n"
         else
-                nmapProgressBar "${nmapType} -sCV -p${basicPorts} -oN nmap/Basic_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
+                nmapProgressBar "${nmapType} -sCV -p${basicPorts} --open -oN nmap/Basic_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
         fi
 
         if [ -f "nmap/Basic_${HOST}.nmap" ] && grep -q "Service Info: OS:" "nmap/Basic_${HOST}.nmap"; then
@@ -247,7 +247,7 @@ UDPScan() {
                 echo
         fi
 
-        nmapProgressBar "sudo ${nmapType} -sU --max-retries 1 --open -oN nmap/UDP_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
+        nmapProgressBar "sudo ${nmapType} -sU --max-retries 1 --open --open -oN nmap/UDP_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
         assignPorts "${HOST}"
 
         if [ -n "${udpPorts}" ]; then
@@ -256,9 +256,9 @@ UDPScan() {
                 printf "${YELLOW}Making a script scan on UDP ports: $(echo "${udpPorts}" | sed 's/,/, /g')\n"
                 printf "${NC}\n"
                 if [ -f /usr/share/nmap/scripts/vulners.nse ]; then
-                        nmapProgressBar "${nmapType} -sCVU --script vulners --script-args mincvss=7.0 -p${udpPorts} -oN nmap/UDP_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
+                        nmapProgressBar "${nmapType} -sCVU --script vulners --script-args mincvss=7.0 -p${udpPorts} --open -oN nmap/UDP_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
                 else
-                        nmapProgressBar "${nmapType} -sCVU -p${udpPorts} -oN nmap/UDP_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
+                        nmapProgressBar "${nmapType} -sCVU -p${udpPorts} --open -oN nmap/UDP_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
                 fi
         else
                 echo
@@ -276,7 +276,7 @@ fullScan() {
         printf "${GREEN}---------------------Starting Nmap Full Scan----------------------\n"
         printf "${NC}\n"
 
-        nmapProgressBar "${nmapType} -p- --max-retries 1 --max-rate 500 --max-scan-delay 20 -T4 -v -oN nmap/Full_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
+        nmapProgressBar "${nmapType} -p- --max-retries 1 --max-rate 500 --max-scan-delay 20 -T4 -v --open -oN nmap/Full_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
         assignPorts "${HOST}"
 
         if [ -z "${basicPorts}" ]; then
@@ -284,7 +284,7 @@ fullScan() {
                 echo
                 printf "${YELLOW}Making a script scan on all ports\n"
                 printf "${NC}\n"
-                nmapProgressBar "${nmapType} -sCV -p${allPorts} -oN nmap/Full_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
+                nmapProgressBar "${nmapType} -sCV -p${allPorts} --open -oN nmap/Full_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
                 assignPorts "${HOST}"
         else
                 cmpPorts "${HOST}"
@@ -299,7 +299,7 @@ fullScan() {
                         echo
                         printf "${YELLOW}Making a script scan on extra ports: $(echo "${extraPorts}" | sed 's/,/, /g')\n"
                         printf "${NC}\n"
-                        nmapProgressBar "${nmapType} -sCV -p${extraPorts} -oN nmap/Full_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
+                        nmapProgressBar "${nmapType} -sCV -p${extraPorts} --open -oN nmap/Full_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
                         assignPorts "${HOST}"
                 fi
         fi
@@ -330,7 +330,7 @@ vulnsScan() {
         else
                 printf "${YELLOW}Running CVE scan on ${portType} ports\n"
                 printf "${NC}\n"
-                nmapProgressBar "${nmapType} -sV --script vulners --script-args mincvss=7.0 -p${ports} -oN nmap/CVEs_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
+                nmapProgressBar "${nmapType} -sV --script vulners --script-args mincvss=7.0 -p${ports} --open -oN nmap/CVEs_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
                 echo
         fi
 
@@ -338,7 +338,7 @@ vulnsScan() {
         printf "${YELLOW}Running Vuln scan on ${portType} ports\n"
         printf "${YELLOW}This may take a while, depending on the number of detected services..\n"
         printf "${NC}\n"
-        nmapProgressBar "${nmapType} -sV --script vuln -p${ports} -oN nmap/Vulns_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
+        nmapProgressBar "${nmapType} -sV --script vuln -p${ports} --open -oN nmap/Vulns_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
         echo
         echo
         echo

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -596,13 +596,13 @@ footer() {
         echo
 
         if [ ${SECONDS} -gt 3600 ]; then
-                let "hours=SECONDS/3600"
-                let "minutes=(SECONDS%3600)/60"
-                let "seconds=(SECONDS%3600)%60"
+                hours=$((SECONDS / 3600))
+                minutes=$(((SECONDS % 3600) / 60))
+                seconds=$(((SECONDS % 3600) % 60))
                 printf "${YELLOW}Completed in ${hours} hour(s), ${minutes} minute(s) and ${seconds} second(s)\n"
         elif [ ${SECONDS} -gt 60 ]; then
-                let "minutes=(SECONDS%3600)/60"
-                let "seconds=(SECONDS%3600)%60"
+                minutes=$(((SECONDS % 3600) / 60))
+                seconds=$(((SECONDS % 3600) % 60))
                 printf "${YELLOW}Completed in ${minutes} minute(s) and ${seconds} second(s)\n"
         else
                 printf "${YELLOW}Completed in ${SECONDS} seconds\n"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -605,7 +605,7 @@ footer() {
         else
                 printf "${YELLOW}Completed in ${SECONDS} seconds\n"
         fi
-        echo
+        printf "${NC}\n"
 }
 
 main() {

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #by @21y4d
 
 RED='\033[0;31m'

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -170,7 +170,7 @@ progressBar() {
         fill="$(printf "%-$((width == 100 ? $2 : ($2 / 2)))s" "#" | tr ' ' '#')"
         empty="$(printf "%-$((width - (width == 100 ? $2 : ($2 / 2))))s" " ")"
         printf "In progress: $1 Scan ($3 elapsed - $4 remaining)   \n"
-        printf "[${fill}>${empty}] $2% done   \n"
+        printf "[${fill}>${empty}] $2%% done   \n"
         printf "\e[2A"
 }
 

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -65,17 +65,17 @@ fi
 
 usage() {
         echo
-        echo -e "${RED}Usage: $0 -H/--host <TARGET-IP> -t/--type <TYPE> [-d/--dns <DNS SERVER> -o/--output <OUTPUT DIRECTORY>]"
-        echo -e "${YELLOW}"
-        echo -e "Scan Types:"
-        echo -e "\tQuick: Shows all open ports quickly (~15 seconds)"
-        echo -e "\tBasic: Runs Quick Scan, then runs a more thorough scan on found ports (~5 minutes)"
-        echo -e "\tUDP  : Runs \"Basic\" on UDP ports \"requires sudo\" (~5 minutes)"
-        echo -e "\tFull : Runs a full range port scan, then runs a thorough scan on new ports (~5-10 minutes)"
-        echo -e "\tVulns: Runs CVE scan and nmap Vulns scan on all found ports (~5-15 minutes)"
-        echo -e "\tRecon: Suggests recon commands, then prompts to automatically run them"
-        echo -e "\tAll  : Runs all the scans (~20-30 minutes)"
-        echo -e "${NC}"
+        printf "${RED}Usage: $0 -H/--host <TARGET-IP> -t/--type <TYPE> [-d/--dns <DNS SERVER> -o/--output <OUTPUT DIRECTORY>]\n"
+        printf "${YELLOW}\n"
+        printf "Scan Types:\n"
+        printf "\tQuick: Shows all open ports quickly (~15 seconds)\n"
+        printf "\tBasic: Runs Quick Scan, then runs a more thorough scan on found ports (~5 minutes)\n"
+        printf "\tUDP  : Runs \"Basic\" on UDP ports \"requires sudo\" (~5 minutes)\n"
+        printf "\tFull : Runs a full range port scan, then runs a thorough scan on new ports (~5-10 minutes)\n"
+        printf "\tVulns: Runs CVE scan and nmap Vulns scan on all found ports (~5-15 minutes)\n"
+        printf "\tRecon: Suggests recon commands, then prompts to automatically run them\n"
+        printf "\tAll  : Runs all the scans (~20-30 minutes)\n"
+        printf "${NC}\n"
         exit 1
 }
 
@@ -83,9 +83,9 @@ header() {
         echo
 
         if [ "${TYPE}" = "All" ]; then
-                echo -e "${YELLOW}Running all scans on ${HOST}"
+                printf "${YELLOW}Running all scans on ${HOST}\n"
         else
-                echo -e "${YELLOW}Running a ${TYPE} scan on ${HOST}"
+                printf "${YELLOW}Running a ${TYPE} scan on ${HOST}\n"
         fi
 
         subnet="$(echo "${HOST}" | cut -d "." -f 1,2,3).0"
@@ -94,17 +94,17 @@ header() {
         nmapType="$(echo "${checkPing}" | head -n 1)"
 
         if [ "${nmapType}" != "nmap" ]; then
-                echo -e "${NC}"
-                echo -e "${YELLOW}No ping detected.. Running with -Pn option!"
-                echo -e "${NC}"
+                printf "${NC}\n"
+                printf "${YELLOW}No ping detected.. Running with -Pn option!\n"
+                printf "${NC}\n"
         fi
 
         ttl="$(echo "${checkPing}" | tail -n 1)"
         if [ "${ttl}" != "nmap -Pn" ]; then
                 osType="$(checkOS "${ttl}")"
-                echo -e "${NC}"
-                echo -e "${GREEN}Host is likely running ${osType}"
-                echo -e "${NC}"
+                printf "${NC}\n"
+                printf "${GREEN}Host is likely running ${osType}\n"
+                printf "${NC}\n"
         fi
 
         echo
@@ -177,9 +177,9 @@ progressBar() {
         [ "$(stty size | cut -d ' ' -f 2)" -le 120 ] && width=50 || width=100
         fill="$(printf "%-$((width == 100 ? $2 : ($2 / 2)))s" "#")"
         empty="$(printf "%-$((width - (width == 100 ? $2 : ($2 / 2))))s" " ")"
-        echo -e "In progress: $1 Scan ($3 elapsed - $4 remaining)   "
-        echo -e "[${fill// /\#}>${empty// / }] $2% done   "
-        echo -ne "\e[2A"
+        printf "In progress: $1 Scan ($3 elapsed - $4 remaining)   \n"
+        printf "[${fill// /\#}>${empty// / }] $2% done   \n"
+        printf "\e[2A"
 }
 
 nmapProgressBar() {
@@ -198,7 +198,7 @@ nmapProgressBar() {
                 progressBar "${scanType:-No}" "${percent:-0}" "${elapsed:-0:00:00}" "${remaining:-0:00:00}"
                 sleep "${refreshRate}"
         done
-        echo -e "\033[0K\r\n\033[0K\r"
+        printf "\033[0K\r\n\033[0K\r\n"
         if [ -e "${outputFile}" ]; then
                 sed -n '/PORT.*STATE.*SERVICE/,/Nmap done at.*/p' "${outputFile}" | head -n-2
         else
@@ -208,8 +208,8 @@ nmapProgressBar() {
 }
 
 quickScan() {
-        echo -e "${GREEN}---------------------Starting Nmap Quick Scan---------------------"
-        echo -e "${NC}"
+        printf "${GREEN}---------------------Starting Nmap Quick Scan---------------------\n"
+        printf "${NC}\n"
 
         nmapProgressBar "${nmapType} -T4 --max-retries 1 --max-scan-delay 20 --defeat-rst-ratelimit --open -oN nmap/Quick_${HOST}.nmap ${HOST} ${DNSSTRING}"
         assignPorts "${HOST}"
@@ -220,11 +220,11 @@ quickScan() {
 }
 
 basicScan() {
-        echo -e "${GREEN}---------------------Starting Nmap Basic Scan---------------------"
-        echo -e "${NC}"
+        printf "${GREEN}---------------------Starting Nmap Basic Scan---------------------\n"
+        printf "${NC}\n"
 
         if [ -z "${basicPorts}" ]; then
-                echo -e "${YELLOW}No ports in quick scan.. Skipping!"
+                printf "${YELLOW}No ports in quick scan.. Skipping!\n"
         else
                 nmapProgressBar "${nmapType} -sCV -p${basicPorts} -oN nmap/Basic_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
         fi
@@ -233,10 +233,10 @@ basicScan() {
                 serviceOS="$(grep "Service Info: OS:" "nmap/Basic_${HOST}.nmap" | cut -d ":" -f 3 | cut -c2- | cut -d ";" -f 1 | head -c-1)"
                 if [ "${osType}" != "${serviceOS}" ]; then
                         osType="${serviceOS}"
-                        echo -e "${NC}"
-                        echo -e "${NC}"
-                        echo -e "${GREEN}OS Detection modified to: ${osType}"
-                        echo -e "${NC}"
+                        printf "${NC}\n"
+                        printf "${NC}\n"
+                        printf "${GREEN}OS Detection modified to: ${osType}\n"
+                        printf "${NC}\n"
                 fi
         fi
 
@@ -246,8 +246,8 @@ basicScan() {
 }
 
 UDPScan() {
-        echo -e "${GREEN}----------------------Starting Nmap UDP Scan----------------------"
-        echo -e "${NC}"
+        printf "${GREEN}----------------------Starting Nmap UDP Scan----------------------\n"
+        printf "${NC}\n"
 
         if [ "${USER}" != 'root' ]; then
                 echo "UDP needs to be run as root, running with sudo..."
@@ -261,8 +261,8 @@ UDPScan() {
         if [ -n "${udpPorts}" ]; then
                 echo
                 echo
-                echo -e "${YELLOW}Making a script scan on UDP ports: $(echo "${udpPorts}" | sed 's/,/, /g')"
-                echo -e "${NC}"
+                printf "${YELLOW}Making a script scan on UDP ports: $(echo "${udpPorts}" | sed 's/,/, /g')\n"
+                printf "${NC}\n"
                 if [ -f /usr/share/nmap/scripts/vulners.nse ]; then
                         nmapProgressBar "${nmapType} -sCVU --script vulners --script-args mincvss=7.0 -p${udpPorts} -oN nmap/UDP_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
                 else
@@ -271,8 +271,8 @@ UDPScan() {
         else
                 echo
                 echo
-                echo -e "${YELLOW}No UDP ports are open"
-                echo -e "${NC}"
+                printf "${YELLOW}No UDP ports are open\n"
+                printf "${NC}\n"
         fi
 
         echo
@@ -281,8 +281,8 @@ UDPScan() {
 }
 
 fullScan() {
-        echo -e "${GREEN}---------------------Starting Nmap Full Scan----------------------"
-        echo -e "${NC}"
+        printf "${GREEN}---------------------Starting Nmap Full Scan----------------------\n"
+        printf "${NC}\n"
 
         nmapProgressBar "${nmapType} -p- --max-retries 1 --max-rate 500 --max-scan-delay 20 -T4 -v -oN nmap/Full_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
         assignPorts "${HOST}"
@@ -290,8 +290,8 @@ fullScan() {
         if [ -z "${basicPorts}" ]; then
                 echo
                 echo
-                echo -e "${YELLOW}Making a script scan on all ports"
-                echo -e "${NC}"
+                printf "${YELLOW}Making a script scan on all ports\n"
+                printf "${NC}\n"
                 nmapProgressBar "${nmapType} -sCV -p${allPorts} -oN nmap/Full_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
                 assignPorts "${HOST}"
         else
@@ -300,13 +300,13 @@ fullScan() {
                         echo
                         echo
                         allPorts=""
-                        echo -e "${YELLOW}No new ports"
-                        echo -e "${NC}"
+                        printf "${YELLOW}No new ports\n"
+                        printf "${NC}\n"
                 else
                         echo
                         echo
-                        echo -e "${YELLOW}Making a script scan on extra ports: $(echo "${extraPorts}" | sed 's/,/, /g')"
-                        echo -e "${NC}"
+                        printf "${YELLOW}Making a script scan on extra ports: $(echo "${extraPorts}" | sed 's/,/, /g')\n"
+                        printf "${NC}\n"
                         nmapProgressBar "${nmapType} -sCV -p${extraPorts} -oN nmap/Full_Extra_${HOST}.nmap ${HOST} ${DNSSTRING}" 2
                         assignPorts "${HOST}"
                 fi
@@ -318,8 +318,8 @@ fullScan() {
 }
 
 vulnsScan() {
-        echo -e "${GREEN}---------------------Starting Nmap Vulns Scan---------------------"
-        echo -e "${NC}"
+        printf "${GREEN}---------------------Starting Nmap Vulns Scan---------------------\n"
+        printf "${NC}\n"
 
         if [ -z "${allPorts}" ]; then
                 portType="basic"
@@ -330,22 +330,22 @@ vulnsScan() {
         fi
 
         if [ ! -f /usr/share/nmap/scripts/vulners.nse ]; then
-                echo -e "${RED}Please install 'vulners.nse' nmap script:"
-                echo -e "${RED}https://github.com/vulnersCom/nmap-vulners"
-                echo -e "${RED}"
-                echo -e "${RED}Skipping CVE scan!"
-                echo -e "${NC}"
+                printf "${RED}Please install 'vulners.nse' nmap script:\n"
+                printf "${RED}https://github.com/vulnersCom/nmap-vulners\n"
+                printf "${RED}\n"
+                printf "${RED}Skipping CVE scan!\n"
+                printf "${NC}\n"
         else
-                echo -e "${YELLOW}Running CVE scan on ${portType} ports"
-                echo -e "${NC}"
+                printf "${YELLOW}Running CVE scan on ${portType} ports\n"
+                printf "${NC}\n"
                 nmapProgressBar "${nmapType} -sV --script vulners --script-args mincvss=7.0 -p${ports} -oN nmap/CVEs_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
                 echo
         fi
 
         echo
-        echo -e "${YELLOW}Running Vuln scan on ${portType} ports"
-        echo -e "${YELLOW}This may take a while, depending on the number of detected services.."
-        echo -e "${NC}"
+        printf "${YELLOW}Running Vuln scan on ${portType} ports\n"
+        printf "${YELLOW}This may take a while, depending on the number of detected services..\n"
+        printf "${NC}\n"
         nmapProgressBar "${nmapType} -sV --script vuln -p${ports} -oN nmap/Vulns_${HOST}.nmap ${HOST} ${DNSSTRING}" 3
         echo
         echo
@@ -364,10 +364,10 @@ recon() {
         done
 
         if [ -n "${missingTools}" ]; then
-                echo -e "${RED}Missing tools:${NC}${missingTools}"
-                echo -e "\n${RED}You can install with:"
-                echo -e "${YELLOW}sudo apt install${missingTools} -y"
-                echo -e "${NC}\n"
+                printf "${RED}Missing tools:${NC}${missingTools}\n"
+                printf "\n${RED}You can install with:\n"
+                printf "${YELLOW}sudo apt install${missingTools} -y\n"
+                printf "${NC}\n\n"
 
                 availableRecon="$(echo "${allRecon}" | tr " " "\n" | grep -vE "$(echo "${missingTools}" | tr " " "|")" | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)"
         else
@@ -379,11 +379,11 @@ recon() {
 
         if [ -n "${availableRecon}" ]; then
                 while [ "${reconCommand}" != "!" ]; do
-                        echo -e "${YELLOW}"
-                        echo -e "Which commands would you like to run?${NC}\nAll (Default), ${availableRecon}Skip <!>\n"
+                        printf "${YELLOW}\n"
+                        printf "Which commands would you like to run?${NC}\nAll (Default), ${availableRecon}Skip <!>\n\n"
                         while [ ${count} -lt ${secs} ]; do
                                 tlimit=$((secs - count))
-                                echo -e "\rRunning Default in (${tlimit}) s: \c"
+                                printf "\rRunning Default in (${tlimit}) s: \c\n"
                                 read -t 1 reconCommand
                                 count=$((count + 1))
                                 [ -n "${reconCommand}" ] && break
@@ -400,21 +400,21 @@ recon() {
                                 echo
                                 echo
                         else
-                                echo -e "${NC}"
-                                echo -e "${RED}Incorrect choice!"
-                                echo -e "${NC}"
+                                printf "${NC}\n"
+                                printf "${RED}Incorrect choice!\n"
+                                printf "${NC}\n"
                         fi
                 done
         else
-                echo -e "${YELLOW}No Recon Recommendations found..."
-                echo -e "${NC}\n\n"
+                printf "${YELLOW}No Recon Recommendations found...\n"
+                printf "${NC}\n\n\n"
         fi
 
 }
 
 reconRecommend() {
-        echo -e "${GREEN}---------------------Recon Recommendations----------------------"
-        echo -e "${NC}"
+        printf "${GREEN}---------------------Recon Recommendations----------------------\n"
+        printf "${NC}\n"
 
         oldIFS="${IFS}"
         IFS=$'\n'
@@ -429,9 +429,9 @@ reconRecommend() {
         fi
 
         if echo "${file}" | grep -i -q http; then
-                echo -e "${NC}"
-                echo -e "${YELLOW}Web Servers Recon:"
-                echo -e "${NC}"
+                printf "${NC}\n"
+                printf "${YELLOW}Web Servers Recon:\n"
+                printf "${NC}\n"
         fi
 
         for line in ${file}; do
@@ -462,9 +462,9 @@ reconRecommend() {
                         for line in ${cms}; do
                                 port="$(grep "${line}" -B1 "nmap/Basic_${HOST}.nmap" | grep "open" | cut -d "/" -f 1)"
                                 if [[ "${cms}" =~ ^(Joomla|WordPress|Drupal)$ ]]; then
-                                        echo -e "${NC}"
-                                        echo -e "${YELLOW}CMS Recon:"
-                                        echo -e "${NC}"
+                                        printf "${NC}\n"
+                                        printf "${YELLOW}CMS Recon:\n"
+                                        printf "${NC}\n"
                                 fi
                                 case "${cms}" in
                                 Joomla!) echo "joomscan --url \"${HOST}:${port}\" | tee \"recon/joomscan_${HOST}_${port}.txt\"" ;;
@@ -476,17 +476,17 @@ reconRecommend() {
         fi
 
         if echo "${file}" | grep -q "25/tcp"; then
-                echo -e "${NC}"
-                echo -e "${YELLOW}SMTP Recon:"
-                echo -e "${NC}"
+                printf "${NC}\n"
+                printf "${YELLOW}SMTP Recon:\n"
+                printf "${NC}\n"
                 echo "smtp-user-enum -U /usr/share/wordlists/metasploit/unix_users.txt -t \"${HOST}\" | tee \"recon/smtp_user_enum_${HOST}.txt\""
                 echo
         fi
 
         if echo "${file}" | grep -q "445/tcp"; then
-                echo -e "${NC}"
-                echo -e "${YELLOW}SMB Recon:"
-                echo -e "${NC}"
+                printf "${NC}\n"
+                printf "${YELLOW}SMB Recon:\n"
+                printf "${NC}\n"
                 echo "smbmap -H \"${HOST}\" | tee \"recon/smbmap_${HOST}.txt\""
                 echo "smbclient -L \"//${HOST}/\" -U \"guest\"% | tee \"recon/smbclient_${HOST}.txt\""
                 if [ "${osType}" = "Windows" ]; then
@@ -496,26 +496,26 @@ reconRecommend() {
                 fi
                 echo
         elif echo "${file}" | grep -q "139/tcp" && [ "${osType}" = "Linux" ]; then
-                echo -e "${NC}"
-                echo -e "${YELLOW}SMB Recon:"
-                echo -e "${NC}"
+                printf "${NC}\n"
+                printf "${YELLOW}SMB Recon:\n"
+                printf "${NC}\n"
                 echo "enum4linux -a \"${HOST}\" | tee \"recon/enum4linux_${HOST}.txt\""
                 echo
         fi
 
         if [ -f "nmap/UDP_Extra_${HOST}.nmap" ] && grep -q "161/udp.*open" "nmap/UDP_Extra_${HOST}.nmap"; then
-                echo -e "${NC}"
-                echo -e "${YELLOW}SNMP Recon:"
-                echo -e "${NC}"
+                printf "${NC}\n"
+                printf "${YELLOW}SNMP Recon:\n"
+                printf "${NC}\n"
                 echo "snmp-check \"${HOST}\" -c public | tee \"recon/snmpcheck_${HOST}.txt\""
                 echo "snmpwalk -Os -c public -v1 \"${HOST}\" | tee \"recon/snmpwalk_${HOST}.txt\""
                 echo
         fi
 
         if echo "${file}" | grep -q "53/tcp"; then
-                echo -e "${NC}"
-                echo -e "${YELLOW}DNS Recon:"
-                echo -e "${NC}"
+                printf "${NC}\n"
+                printf "${YELLOW}DNS Recon:\n"
+                printf "${NC}\n"
                 echo "host -l \"${HOST}\" \"${DNSSERVER}\" | tee \"recon/hostname_${HOST}.txt\""
                 echo "dnsrecon -r \"${subnet}/24\" -n \"${DNSSERVER}\" | tee \"recon/dnsrecon_${HOST}.txt\""
                 echo "dnsrecon -r 127.0.0.0/24 -n \"${DNSSERVER}\" | tee \"recon/dnsrecon-local_${HOST}.txt\""
@@ -524,9 +524,9 @@ reconRecommend() {
         fi
 
         if echo "${file}" | grep -q "389/tcp"; then
-                echo -e "${NC}"
-                echo -e "${YELLOW}ldap Recon:"
-                echo -e "${NC}"
+                printf "${NC}\n"
+                printf "${YELLOW}ldap Recon:\n"
+                printf "${NC}\n"
                 echo "ldapsearch -x -h \"${HOST}\" -s base | tee \"recon/ldapsearch_${HOST}.txt\""
                 echo "ldapsearch -x -h \"${HOST}\" -b \"\$(grep rootDomainNamingContext \"recon/ldapsearch_${HOST}.txt\" | cut -d ' ' -f2)\" | tee \"recon/ldapsearch_DC_${HOST}.txt\""
                 echo "nmap -Pn -p 389 --script ldap-search --script-args 'ldap.username=\"\$(grep rootDomainNamingContext \"recon/ldapsearch_${HOST}.txt\" | cut -d \\" \\" -f2)\"' \"${HOST}\" -oN \"recon/nmap_ldap_${HOST}.txt\""
@@ -534,9 +534,9 @@ reconRecommend() {
         fi
 
         if echo "${file}" | grep -q "1521/tcp"; then
-                echo -e "${NC}"
-                echo -e "${YELLOW}Oracle Recon:"
-                echo -e "${NC}"
+                printf "${NC}\n"
+                printf "${YELLOW}Oracle Recon:\n"
+                printf "${NC}\n"
                 echo "odat sidguesser -s \"${HOST}\" -p 1521"
                 echo "odat passwordguesser -s \"${HOST}\" -p 1521 -d XE --accounts-file accounts/accounts-multiple.txt"
                 echo
@@ -553,8 +553,8 @@ runRecon() {
         echo
         echo
         echo
-        echo -e "${GREEN}---------------------Running Recon Commands----------------------"
-        echo -e "${NC}"
+        printf "${GREEN}---------------------Running Recon Commands----------------------\n"
+        printf "${NC}\n"
 
         oldIFS="${IFS}"
         IFS=$'\n'
@@ -571,14 +571,14 @@ runRecon() {
                 currentScan="$(echo "${line}" | cut -d " " -f 1 | sort | uniq | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)"
                 fileName="$(echo "${line}" | awk -F "recon/" '{print $2}' | head -c-1)"
                 if [ -n "${fileName}" ] && [ ! -f recon/"${fileName}" ]; then
-                        echo -e "${NC}"
-                        echo -e "${YELLOW}Starting ${currentScan} scan"
-                        echo -e "${NC}"
+                        printf "${NC}\n"
+                        printf "${YELLOW}Starting ${currentScan} scan\n"
+                        printf "${NC}\n"
                         eval "${line}"
-                        echo -e "${NC}"
-                        echo -e "${YELLOW}Finished ${currentScan} scan"
-                        echo -e "${NC}"
-                        echo -e "${YELLOW}========================="
+                        printf "${NC}\n"
+                        printf "${YELLOW}Finished ${currentScan} scan\n"
+                        printf "${NC}\n"
+                        printf "${YELLOW}=========================\n"
                 fi
         done
 
@@ -591,21 +591,21 @@ runRecon() {
 
 footer() {
 
-        echo -e "${GREEN}---------------------Finished all Nmap scans---------------------"
-        echo -e "${NC}"
+        printf "${GREEN}---------------------Finished all Nmap scans---------------------\n"
+        printf "${NC}\n"
         echo
 
         if [ ${SECONDS} -gt 3600 ]; then
                 let "hours=SECONDS/3600"
                 let "minutes=(SECONDS%3600)/60"
                 let "seconds=(SECONDS%3600)%60"
-                echo -e "${YELLOW}Completed in ${hours} hour(s), ${minutes} minute(s) and ${seconds} second(s)"
+                printf "${YELLOW}Completed in ${hours} hour(s), ${minutes} minute(s) and ${seconds} second(s)\n"
         elif [ ${SECONDS} -gt 60 ]; then
                 let "minutes=(SECONDS%3600)/60"
                 let "seconds=(SECONDS%3600)%60"
-                echo -e "${YELLOW}Completed in ${minutes} minute(s) and ${seconds} second(s)"
+                printf "${YELLOW}Completed in ${minutes} minute(s) and ${seconds} second(s)\n"
         else
-                echo -e "${YELLOW}Completed in ${SECONDS} seconds"
+                printf "${YELLOW}Completed in ${SECONDS} seconds\n"
         fi
         echo
 }
@@ -650,9 +650,9 @@ if [ -z "${TYPE}" ] || [ -z "${HOST}" ]; then
 fi
 
 if ! [[ "${HOST}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] && ! [[ "${HOST}" =~ ^([A-Za-z0-9-]{1,63}\.)+[A-Za-z]{2,6}$ ]]; then
-        echo -e "${RED}"
-        echo -e "${RED}Invalid IP or URL!"
-        echo -e "${RED}"
+        printf "${RED}\n"
+        printf "${RED}Invalid IP or URL!\n"
+        printf "${RED}\n"
         usage
 fi
 
@@ -660,8 +660,8 @@ if [[ "${TYPE}" =~ ^(Quick|Basic|UDP|Full|Vulns|Recon|All|quick|basic|udp|full|v
         mkdir -p "${OUTPUTDIR}" && cd "${OUTPUTDIR}" && mkdir -p nmap/ || usage
         main | tee "nmapAutomator_${HOST}_${TYPE}.txt"
 else
-        echo -e "${RED}"
-        echo -e "${RED}Invalid Type!"
-        echo -e "${RED}"
+        printf "${RED}\n"
+        printf "${RED}Invalid Type!\n"
+        printf "${RED}\n"
         usage
 fi

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -53,12 +53,11 @@ if [ -z "$TYPE" ]; then
 fi
 
 if [ -n "$DNS" ]; then
-        DNSSTRING="--dns-server="$DNS
-        DNSSERVER=$DNS
+        DNSSERVER="${DNS}"
 else
-        DNSSTRING="--dns-server=1.1.1.1"
         DNSSERVER="1.1.1.1"
 fi
+DNSSTRING="--dns-server=${DNSSERVER}"
 
 if [ -z "$OUTPUTDIR" ]; then
         OUTPUTDIR="${HOST}"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -569,7 +569,7 @@ runRecon() {
 
         for line in ${reconCommands}; do
                 currentScan="$(echo "${line}" | cut -d " " -f 1 | sort -u | tr "\n" "," | sed 's/,/,\ /g' | head -c-2)"
-                fileName="$(echo "${line}" | awk -F "recon/" "{print ${TYPE}}" | head -c-1)"
+                fileName="$(echo "${line}" | awk -F "recon/" '{print $2}' | head -c-1)"
                 if [ -n "${fileName}" ] && [ ! -f recon/"${fileName}" ]; then
                         echo -e "${NC}"
                         echo -e "${YELLOW}Starting ${currentScan} scan"

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -200,7 +200,7 @@ nmapProgressBar() {
         done
         printf "\033[0K\r\n\033[0K\r\n"
         if [ -e "${outputFile}" ]; then
-                sed -n '/PORT.*STATE.*SERVICE/,/Nmap done at.*/p' "${outputFile}" | head -n-2
+                sed -n '/PORT.*STATE.*SERVICE/,/^$/p' "${outputFile}"
         else
                 cat "${tmpOutputFile}"
         fi

--- a/nmapAutomator.sh
+++ b/nmapAutomator.sh
@@ -37,12 +37,12 @@ while [ $# -gt 0 ]; do
                 shift
                 ;;
         *)
-                POSITIONAL+=("$1")
+                POSITIONAL="${POSITIONAL} $1"
                 shift
                 ;;
         esac
 done
-set -- "${POSITIONAL[@]}"
+set -- ${POSITIONAL}
 
 if [ -z "${HOST}" ]; then
         HOST="$1"


### PR DESCRIPTION
These commits make the script 100% POSIX (tested in `dash`) except for the tools that cannot be converted, such as `nmap`, `ping`, and the scan/vuln tools (`nikto`, `ffuf`, etc).

The changes from #42 are also here (as I thought they would have been merged before I finished), so I recommend to merge first the other pull request and then check the changes here.

It shall be noted that the changes from #42 introduced a little bug (in a Full Scan the same ports used in the Quick Scan where re-detected), as well as showing (in some cases when running as root) closed ports. These two bugs are fixed in this pull request, though nmap is now run with the `--open` flag (most recent commit) to only show open ports (in the commit message I explained more, and also suggested adding a new flag to `nmapAutomator` called `--show-all-ports` that basically runs nmap without the `--open` flag).

Finally, this pull request fixes the frozen progress bar (Full Scan) when running the script as root 🙂